### PR TITLE
Refactor the Sign In component

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,1 @@
-> 1%
+defaults

--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export DATABASE_USER=sm
 export DATABASE_PASSWORD=sm_password
 

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export CONTENT_PREVIEW_MODE=true
 
 export STORYBLOK_TOKEN=noop

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -60,7 +60,7 @@ module Authentication
         session[:user] = user.id
         flash[:notice] = 'You are now signed in'
       else
-        flash[:alert] = 'Please verify your account by clicking on the link in the verification email sent to you'
+        flash[:alert] = 'Cannot sign you in just yet - please verify your account by clicking on the link in the verification email sent to you'
       end
 
       {


### PR DESCRIPTION
- Use the Firebase Auth `.onAuthStateChanged` trigger to handle the server sign in – this decouples the server sign in logic from the Firebase UI flows.
- Explicitly sign out the Firebase Auth session after we have a successful server sign in, otherwise signing out on the server won't sign out the Firebase Auth session.