### PR TITLE
Don't update the User `last_seen_at` when signing in

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -90,7 +90,6 @@ module Authentication
             u.display_name = auth_data['name']
             u.email = auth_data['email']
             u.email_verified = auth_data['email_verified']
-            u.last_seen_at = DateTime.current
             u.save!
           end
       end


### PR DESCRIPTION
This causes a "full" update to the User record (i.e. with an update to the `updated_at` timestamp) when signing in, and is unnnecessary because we `touch` the `last_seen_at` whenever we load up `current_user` anyway (which is a lighter-weight update).