### PR TITLE
Subscription: users must now specify a timezone for their schedule

### DIFF
--- a/app/lib/time_zone_schedule_converter.rb
+++ b/app/lib/time_zone_schedule_converter.rb
@@ -1,0 +1,69 @@
+module TimeZoneScheduleConverter
+  class << self
+    def convert(from_zone:, to_zone:, days:, hour:)
+      if hour.blank? || to_zone == from_zone
+        return {
+          days: days,
+          hour: hour
+        }
+      end
+
+      adjusted_hour = ActiveSupport::TimeZone[from_zone]
+        .parse("#{hour}:00:00")
+        .in_time_zone(to_zone)
+        .hour
+
+      moved_forwards = moved_forwards? from_zone, to_zone
+
+      adjusted_days = adjust_days(
+        days,
+        hour,
+        adjusted_hour,
+        moved_forwards
+      )
+
+      {
+        days: adjusted_days,
+        hour: adjusted_hour
+      }
+    end
+
+    private
+
+    def moved_forwards?(from_zone, to_zone)
+      from_zone = ActiveSupport::TimeZone[from_zone]
+      to_zone = ActiveSupport::TimeZone[to_zone]
+
+      (from_zone.utc_offset - to_zone.utc_offset).negative?
+    end
+
+    def adjust_days(days, hour, adjusted_hour, moved_forwards)
+      return days if days.size == Date::ABBR_DAYNAMES.size
+
+      moved_to_previous_days = !moved_forwards && adjusted_hour > hour
+      moved_to_next_days = moved_forwards && adjusted_hour < hour
+
+      if moved_to_previous_days
+        offset_days days, -1
+      elsif moved_to_next_days
+        offset_days days, 1
+      else
+        days
+      end
+    end
+
+    def offset_days(days, offset)
+      days.map do |d|
+        new_ix = Date::ABBR_DAYNAMES.index(d) + offset
+        new_ix = if new_ix >= Date::ABBR_DAYNAMES.size
+                   0
+                 elsif new_ix.negative?
+                   Date::ABBR_DAYNAMES.size - 1
+                 else
+                   new_ix
+                 end
+        Date::ABBR_DAYNAMES[new_ix]
+      end
+    end
+  end
+end

--- a/app/views/subscriptions/_card.html.erb
+++ b/app/views/subscriptions/_card.html.erb
@@ -31,9 +31,11 @@
         <%= t('concepts.schedule').capitalize %>:
       </span>
       <br />
-      <%= subscription.days_utc.to_sentence %>
+      <%= ActiveSupport::TimeZone[subscription.user_timezone].to_s %>
       <br />
-      <%= subscription.hours_utc.map(&method(:subscription_format_hour_slot)).to_sentence %>
+      <%= subscription.days.to_sentence %>
+      <br />
+      <%= subscription_format_hour_slot subscription.hour %>
     </p>
 
     <div class="card-text mb-3">

--- a/app/views/subscriptions/_form.html.erb
+++ b/app/views/subscriptions/_form.html.erb
@@ -21,8 +21,18 @@
         </div>
         <div class="card-body">
           <%=
-            form.select :days_utc,
-              Subscription::DAYS,
+            form.time_zone_select :user_timezone,
+              nil,
+              {
+                label: t('.user_timezone_label'),
+                default: 'UTC'
+              },
+              { class: 'selectpicker' }
+          %>
+
+          <%=
+            form.select :days,
+              Date::ABBR_DAYNAMES,
               { label: t('.days_label') },
               {
                 class: 'selectpicker',
@@ -31,16 +41,13 @@
           %>
 
           <%=
-            form.select :hours_utc,
+            form.select :hour,
               subscription_hours_options,
               {
-                label: t('.hours_label'),
-                help: t('.hours_help_text')
+                label: t('.hour_label'),
+                help: t('.hour_help_text')
               },
-              {
-                class: 'selectpicker',
-                multiple: true
-              }
+              { class: 'selectpicker' }
           %>
         </div>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,9 +48,10 @@ en:
       explanation: "Make the path work for you! Now it’s the time to customize the schedule to receive your note, the languages you want to read it in and if you don’t want anyone to find out, you can also choose to have a disguised subject line."
       schedule_section: Choose the schedule
       languages_section: Choose the language(s)
+      user_timezone_label: "Your timezone:"
       days_label: "Set the best days for you (one or more):"
-      hours_label: "Set the best time slots (one or more):"
-      hours_help_text: "We cannot guarantee but usually it will come in that slot"
+      hour_label: "Set the best time slot for you:"
+      hour_help_text: "We cannot guarantee this time slot but will do our best"
       main_language_label: "Main language"
       other_languages_label: "Others (optional):"
       make_active: Make this subscription active?

--- a/db/migrate/20190327141648_add_user_timezone_to_subscriptions.rb
+++ b/db/migrate/20190327141648_add_user_timezone_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddUserTimezoneToSubscriptions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subscriptions, :user_timezone, :string, default: 'UTC'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_24_204505) do
+ActiveRecord::Schema.define(version: 2019_03_27_141648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2019_02_24_204505) do
     t.datetime "last_delivered_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "user_timezone", default: "UTC"
     t.index ["active"], name: "index_subscriptions_on_active"
     t.index ["user_id", "course_slug"], name: "index_subscriptions_on_user_id_and_course_slug", unique: true
     t.index ["user_id"], name: "index_subscriptions_on_user_id"

--- a/spec/lib/time_zone_schedule_converter_spec.rb
+++ b/spec/lib/time_zone_schedule_converter_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe TimeZoneScheduleConverter do
+  describe '.convert' do
+    subject do
+      TimeZoneScheduleConverter.convert(
+        from_zone: from_zone,
+        to_zone: to_zone,
+        days: days,
+        hour: hour
+      )
+    end
+
+    context 'when hour is blank' do
+      let(:from_zone) { 'UTC' }
+      let(:to_zone) { 'Amsterdam' }
+      let(:days) { ['Mon'] }
+      let(:hour) { nil }
+
+      it 'returns the same days and hour' do
+        expect(subject).to eq(
+          days: days,
+          hour: hour
+        )
+      end
+    end
+
+    context 'when to_zone is the same as from_zone' do
+      let(:from_zone) { 'Amsterdam' }
+      let(:to_zone) { 'Amsterdam' }
+      let(:days) { ['Mon'] }
+      let(:hour) { 0 }
+
+      it 'returns the same days and hour' do
+        expect(subject).to eq(
+          days: days,
+          hour: hour
+        )
+      end
+    end
+
+    context 'when all days are provided' do
+      let(:from_zone) { 'UTC' }
+      let(:to_zone) { 'Amsterdam' }
+      let(:days) { Date::ABBR_DAYNAMES }
+      let(:hour) { 23 }
+
+      it 'returns the adjusted hour but same days' do
+        expect(subject).to eq(
+          days: days,
+          hour: 1
+        )
+      end
+    end
+
+    context 'when some days are provided' do
+      let(:days) { %w[Sun Wed Sat] }
+
+      context 'when the adjusted hour doesn\'t affect the days' do
+        let(:from_zone) { 'UTC' }
+        let(:to_zone) { 'Amsterdam' }
+        let(:hour) { 12 }
+
+        it 'returns the adjusted hour and same days' do
+          expect(subject).to eq(
+            days: days,
+            hour: 14
+          )
+        end
+      end
+
+      context 'when the adjusted hour moves behind into previous day(s)' do
+        let(:from_zone) { 'UTC' }
+        let(:to_zone) { 'Greenland' }
+        let(:hour) { 1 }
+
+        it 'returns the adjusted hour and previous day(s)' do
+          expect(subject).to eq(
+            days: %w[Sat Tue Fri],
+            hour: 23
+          )
+        end
+      end
+
+      context 'when the adjusted hour moves forward into next days' do
+        let(:from_zone) { 'UTC' }
+        let(:to_zone) { 'Amsterdam' }
+        let(:hour) { 23 }
+
+        it 'returns the adjusted hour and next days' do
+          expect(subject).to eq(
+            days: %w[Mon Thu Sun],
+            hour: 1
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the database, we still store the data in normalised UTC – we convert back and forth between the user's timezone and UTC so the user only sees the schedule in their selected timezone.

BREAKING CHANGE: we now only allow users to select **1** time slot – this makes adjusting the schedule based on the user's timezone possible (with multiple time slots there are cases where it's impossible to convert to/from the user's timezones, due to the days adjustment [forward or backwards]).

KNOWN ISSUE: this doesn't handle daylight savings at all :( The worst case is that users receive emails an hour before their actual scheduled time slot (note: that since schedules are shown to users as two hours, but processed every hour, the case where daylight savings would result in it being sent one hour forward would still be okay as it's still within the advertised time slot).