### PR TITLE
Set up Pages in Storyblok

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,4 +29,9 @@ class ApplicationController < ActionController::Base
     CoursesService.new(STORYBLOK_CLIENT)
   end
   memoize :courses_service
+
+  def pages_service
+    PagesService.new(STORYBLOK_CLIENT)
+  end
+  memoize :pages_service
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,11 @@
 class PagesController < ApplicationController
-  def landing; end
+  def landing
+    params[:id] = 'landing'
+    show
+  end
+
+  def show
+    @page = pages_service.get params[:id]
+    render :show
+  end
 end

--- a/app/mappers/page_mapper.rb
+++ b/app/mappers/page_mapper.rb
@@ -1,0 +1,8 @@
+class PageMapper
+  include ContentMapper
+
+  key :slug, from: 'slug'
+  key :uuid, from: 'uuid'
+
+  key :content_html, from: %w[content content_html]
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,0 +1,3 @@
+class Page < ContentModel
+  attribute :content_html, String, present: true
+end

--- a/app/services/courses_service.rb
+++ b/app/services/courses_service.rb
@@ -1,20 +1,4 @@
-class CoursesService
-  class CmsAccessError < StandardError; end
-
-  class NotFound < StandardError
-    attr_reader :type, :identifier
-
-    def initialize(message = nil, type = nil, identifier = nil)
-      @type = type
-      @identifier = identifier
-      super(message)
-    end
-  end
-
-  def initialize(storyblok_client)
-    @client = storyblok_client
-  end
-
+class CoursesService < StoryblokService
   def list
     response = @client.stories(
       starts_with: 'courses',
@@ -29,34 +13,28 @@ class CoursesService
   end
 
   def get(slug)
-    raise NotFound.new(nil, 'Course', nil) if slug.blank?
+    raise NotFound.new(type: 'Course') if slug.blank?
 
-    response = @client.story "courses/#{slug}"
+    path = "courses/#{slug}"
+    response = fetch path
     story = response.dig 'data', 'story'
     deserialize_course story
-  rescue RestClient::NotFound
-    raise NotFound.new(nil, 'Course', slug)
-  rescue RestClient::RequestFailed => e
-    Rails.logger.error "[#{self.class.name}] Failed to fetch course '#{slug}' from Storyblok – exception: #{e.inspect}"
-
-    raise CmsAccessError
   end
 
   def get_course_and_lesson(course_slug, lesson_slug)
-    raise NotFound.new(nil, 'Lessons', nil) if course_slug.blank? || lesson_slug.blank?
+    raise NotFound.new(type: 'Lesson') if course_slug.blank? || lesson_slug.blank?
 
     course = get course_slug
     lesson = course.lessons.find { |l| l.slug == lesson_slug }
 
-    raise NotFound.new(nil, 'Lessons', "#{course_slug}/#{lesson_slug}") if lesson.blank?
+    raise NotFound.new(type: 'Lessons', id: "#{course_slug}/#{lesson_slug}") if lesson.blank?
 
     [course, lesson]
   end
 
   private
 
-  def deserialize_course(hash)
-    mapped = CourseMapper.map_from hash
-    Course.new mapped
+  def deserialize_course(story)
+    deserialize story, CourseMapper, Course
   end
 end

--- a/app/services/pages_service.rb
+++ b/app/services/pages_service.rb
@@ -1,0 +1,11 @@
+class PagesService < StoryblokService
+  def get(slug)
+    raise NotFound.new(type: 'Page') if slug.blank?
+
+    path = "pages/#{slug}"
+
+    response = fetch path
+    story = response.dig 'data', 'story'
+    deserialize story, PageMapper, Page
+  end
+end

--- a/app/services/storyblok_service.rb
+++ b/app/services/storyblok_service.rb
@@ -1,0 +1,37 @@
+class StoryblokService
+  class CmsAccessError < StandardError; end
+
+  class NotFound < StandardError
+    attr_reader :path, :type, :id
+
+    def initialize(message = nil, path: nil, type: nil, id: nil)
+      @path = path
+      @type = type
+      @id = id
+      super(message)
+    end
+  end
+
+  attr_reader :client
+
+  def initialize(storyblok_client)
+    @client = storyblok_client
+  end
+
+  def fetch(path)
+    @client.story path
+  rescue RestClient::NotFound
+    raise NotFound.new path: path
+  rescue RestClient::RequestFailed => e
+    Rails.logger.error "[#{self.class.name}] Failed to fetch path '#{path}' from Storyblok – exception: #{e.inspect}"
+
+    raise CmsAccessError
+  end
+
+  private
+
+  def deserialize(hash, mapper, model_class)
+    mapped = mapper.map_from hash
+    model_class.new mapped
+  end
+end

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,0 +1,3 @@
+<%= tag.section id: "page-#{@page.slug}" do %>
+  <%= raw @page.content_html %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
 
     resources :subscriptions, only: %i[index]
 
+    resources :pages, only: %i[show]
     root to: 'pages#landing'
   end
 

--- a/spec/routing/pages_routing_spec.rb
+++ b/spec/routing/pages_routing_spec.rb
@@ -5,5 +5,9 @@ RSpec.describe PagesController, type: :routing do
     it 'routes to #landing' do
       expect(get: '/').to route_to('pages#landing')
     end
+
+    it 'routes to #show' do
+      expect(get: '/pages/foo').to route_to('pages#show', id: 'foo')
+    end
   end
 end


### PR DESCRIPTION
This allows us to define content (in HTML) for any page on the Soul Medicine site via Storyblok (the CMS we're using).

The folder 'Pages' in Storyblok contains all page entries. Currently, each `page` entry has a single `content_html` field. Here you can add any HTML, which will then get rendered on the site.

To start with, we have the `landing` page hooked up in this changeset.

Any page defined in Storyblok can be rendered on the URL `/pages/:id` (where `:id` is the 'slug' defined for that entry in Storyblok). As a special case, the homepage renders the content of the `landing` page.

Using this set up, we can define any number of pages (including linked pages, i.e. pages linked to from other page entries in Storyblok).