### PR TITLE
Use the new `code` field in the Pages from Storyblok

### DIFF
--- a/app/mappers/page_mapper.rb
+++ b/app/mappers/page_mapper.rb
@@ -4,5 +4,5 @@ class PageMapper
   key :slug, from: 'slug'
   key :uuid, from: 'uuid'
 
-  key :content_html, from: %w[content content_html]
+  key :content_html, from: %w[content content_html code]
 end


### PR DESCRIPTION
This was changed on Storyblok to support an HTML code editor.