### PR TITLE
Move the languages selector from the header to the courses index page

### DIFF
--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -30,25 +30,6 @@
         <% else %>
           <%= header_nav_item t('site-header.sign-in'), auth_sign_in_path, icon_name: 'sign-in-alt' %>
         <% end %>
-
-        <%= header_nav_separator %>
-
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarLangSelector" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= LocalesService.language_name(LocalesService.current) %>
-          </a>
-          <div class="dropdown-menu dropdown-menu-right <%= text_direction %>" dir="<%= text_direction %>" aria-labelledby="navbarLangSelector">
-            <% LocalesService.enabled.each do |l| %>
-              <% if LocalesService.current == l %>
-                <span class="dropdown-item">
-                  <%= LocalesService.language_name(l) %>
-                </span>
-              <% else %>
-                <%= link_to LocalesService.language_name(l), params_with_locale(l), class: 'dropdown-item' %>
-              <% end %>
-            <% end %>
-          </div>
-        </li>
       </ul>
     </div>
   </nav>

--- a/app/views/application/_languages_selector.html.erb
+++ b/app/views/application/_languages_selector.html.erb
@@ -1,0 +1,18 @@
+<div class="text-right mb-2">
+  <div class="btn-group" role="group" aria-label="Languages selector">
+    <button id="languagesSelectorDropdown" type="button" class="btn btn-light dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <%= LocalesService.language_name(LocalesService.current) %>
+    </button>
+    <div class="dropdown-menu dropdown-menu-right <%= text_direction %>" dir="<%= text_direction %>" aria-labelledby="languagesSelectorDropdown">
+      <% LocalesService.enabled.each do |l| %>
+        <% if LocalesService.current == l %>
+          <span class="dropdown-item">
+            <%= LocalesService.language_name(l) %>
+          </span>
+        <% else %>
+          <%= link_to LocalesService.language_name(l), params_with_locale(l), class: 'dropdown-item' %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -3,6 +3,8 @@
 %>
 
 <section class="courses-page">
+  <%= render partial: 'languages_selector' %>
+
   <% if @courses.blank? %>
     <div class="alert alert-warning" role="alert">
       <%= t('.no_courses') %>


### PR DESCRIPTION
Since the only translated content are the courses, it makes sense to only show switching of languages on the courses index page.

Note: we still make use of the site wide I18n handling… so if/when we do start adding site-wide translations then it would make sense to move this language selector back into the header.