### PR TITLE
Make the timezone select searchable on the subscription form page

### DIFF
--- a/app/views/subscriptions/_form.html.erb
+++ b/app/views/subscriptions/_form.html.erb
@@ -27,7 +27,12 @@
                 label: t('.user_timezone_label'),
                 default: 'UTC'
               },
-              { class: 'selectpicker' }
+              {
+                class: 'selectpicker',
+                data: {
+                  'live-search': true
+                }
+              }
           %>
 
           <%=


### PR DESCRIPTION
<img width="562" alt="Screenshot 2019-08-22 12 28 26" src="https://user-images.githubusercontent.com/31973/63511214-7cf63100-c4d8-11e9-8943-98b46de42162.png">
