### PR TITLE
Fix log level for local development

### DIFF
--- a/config/initializers/storyblok_client.rb
+++ b/config/initializers/storyblok_client.rb
@@ -6,6 +6,7 @@ STORYBLOK_CLIENT = if ENV['CONTENT_PREVIEW_MODE'] == 'true'
                      Storyblok::Client.new(
                        token: storyblok_token,
                        logger: logger,
+                       log_level: Rails.logger.level,
                        version: 'draft'
                      )
                    else
@@ -19,6 +20,7 @@ STORYBLOK_CLIENT = if ENV['CONTENT_PREVIEW_MODE'] == 'true'
                        cache: cache,
                        token: storyblok_token,
                        logger: logger,
+                       log_level: Rails.logger.level,
                        version: 'published'
                      )
                    end


### PR DESCRIPTION
Previously, the Storyblok client was resetting the Rails logger to `INFO` level.