### PR TITLE
Fix env files for newer Docker Compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,38 +1,38 @@
 #!/usr/bin/env bash
 
-export DATABASE_USER=sm
-export DATABASE_PASSWORD=sm_password
+DATABASE_USER=sm
+DATABASE_PASSWORD=sm_password
 
-export DATABASE_NAME=soulmedicine
+DATABASE_NAME=soulmedicine
 
-export REDIS_URL="redis://localhost:6379"
+REDIS_URL="redis://localhost:6379"
 
-export REDIS_CACHE_URL="redis://localhost:6380"
+REDIS_CACHE_URL="redis://localhost:6380"
 
-export ENABLED_LOCALES="en,fr,de,ur,ar"
+ENABLED_LOCALES="en,fr,de,ur,ar"
 
-export ADMIN_BASIC_AUTH="admin:password"
+ADMIN_BASIC_AUTH="admin:password"
 
-export EMAIL_FROM_ADDRESS="\"test\" <test@example.org>"
-export SMTP_ADDRESS="127.0.0.1"
-export SMTP_PORT="1025"
+EMAIL_FROM_ADDRESS="\"test\" <test@example.org>"
+SMTP_ADDRESS="127.0.0.1"
+SMTP_PORT="1025"
 
-export SITE_BASE_URL="http://localhost:3000"
+SITE_BASE_URL="http://localhost:3000"
 
 # If this set to `true` make sure the `STORYBLOK_TOKEN` used has preview access level
-export CONTENT_PREVIEW_MODE=true
+CONTENT_PREVIEW_MODE=true
 
 # ------------------------------------------------------------------------------
 # Set these in your .env.local
 
-# export STORYBLOK_TOKEN="..."
+# STORYBLOK_TOKEN="..."
 
 # Firebase Authentication
-# export FIREBASE_PROJECT_ID="..."
-# export FIREBASE_API_KEY="..."
+# FIREBASE_PROJECT_ID="..."
+# FIREBASE_API_KEY="..."
 
 # Rollbar (only if you want to test errors are being reported locally)
-# export ROLLBAR_ACCESS_TOKEN="..."
-# export ROLLBAR_ENV=dev
+# ROLLBAR_ACCESS_TOKEN="..."
+# ROLLBAR_ENV=dev
 
-# export GOOGLE_ANALYTICS_ID="..."
+# GOOGLE_ANALYTICS_ID="..."

--- a/.env.test
+++ b/.env.test
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-export CONTENT_PREVIEW_MODE=true
+CONTENT_PREVIEW_MODE=true
 
-export STORYBLOK_TOKEN=noop
+STORYBLOK_TOKEN=noop
 
-export FIREBASE_PROJECT_ID=noop
-export FIREBASE_API_KEY=noop
+FIREBASE_PROJECT_ID=noop
+FIREBASE_API_KEY=noop


### PR DESCRIPTION
Annoyingly, newer versions of Docker Compose don't support `export` in the `.env` file (which gets loaded by Docker Compose automatically, even though technically we don't need it to).