### PR TITLE
Upgrade local PostgreSQL to match Heroku (14.8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       RAILS_ENV: test
     services:
       postgres:
-        image: postgres:10.5-alpine
+        image: postgres:14.8-alpine
         env:
           POSTGRES_USER: sm
           POSTGRES_PASSWORD: sm_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   postgres:
-    image: 'postgres:10.5-alpine'
+    image: 'postgres:14.8-alpine'
     volumes:
       - 'pgdata:/var/lib/postgresql/data'
     environment:


### PR DESCRIPTION
This updates out local environment and test setup to use [PostgreSQL 14.8](https://www.postgresql.org/docs/release/14.8/) instead of [PostgreSQL 10.5](https://www.postgresql.org/docs/release/10.5/).

Version 14.8 is currently used in production.