### PR TITLE
Check that the reactions `set_from_email` `redirect_url` is legit

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -31,6 +31,10 @@ class ReactionsController < ApplicationController
   end
 
   def redirect_url
-    params[:redirect_url].presence || course_lesson_path(@reaction.course_slug, @reaction.lesson_slug)
+    if params[:redirect_url].present? && params[:redirect_url].starts_with?('https://soulmedicine.io/')
+      params[:redirect_url]
+    else
+      course_lesson_path(@reaction.course_slug, @reaction.lesson_slug)
+    end
   end
 end

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -31,7 +31,7 @@ class ReactionsController < ApplicationController
   end
 
   def redirect_url
-    if params[:redirect_url].present? && params[:redirect_url].starts_with?('https://soulmedicine.io/')
+    if params[:redirect_url].present? && URI(params[:redirect_url]).host == 'soulmedicine.io'
       params[:redirect_url]
     else
       course_lesson_path(@reaction.course_slug, @reaction.lesson_slug)

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -157,5 +157,18 @@ RSpec.describe 'Reactions', type: :request do
       expect(lesson_reaction.reaction_name).to eq reaction_name
       expect(lesson_reaction.user).to eq user
     end
+
+    it 'does not redirect to arbitrary websites' do
+      response = get set_from_email_course_lesson_reaction_url(
+        course_id: course.slug,
+        lesson_id: lesson.slug,
+        reaction_name: reaction_name,
+        user_id: user.to_sgid_param(for: :set_reaction),
+        redirect_to: 'https://en.wikipedia.org'
+      )
+
+      expect(response).to redirect_to(course_lesson_path(course.slug, lesson.slug))
+      expect(response).not_to redirect_to('https://en.wikipedia.org')
+    end
   end
 end


### PR DESCRIPTION
- These email reactions URLs look like https://soulmedicine.io/pathways/[...]/reaction/set_from_email?reaction_name=[...]&redirect_url=https://soulmedicine.io[...].
- Fixes https://github.com/chaynHQ/soulmedicine/security/code-scanning/1.