### PR TITLE
Fix truncating text issues on lesson cards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   erb_javascript_rails:

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'meta-tags', '~> 2.11', '>= 2.11.1'
 gem 'active_model_serializers', '~> 0.10.9'
 gem 'premailer-rails', '~>1.10.3'
 gem 'gemoji'
-gem 'truncato'
+gem 'truncato', '~> 0.7.12'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.0.2)
-    mini_portile2 (2.8.2)
+    mini_portile2 (2.8.4)
     minitest (5.14.0)
     msgpack (1.7.1)
     multi_json (1.13.1)
@@ -297,7 +297,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     timecop (0.9.1)
-    truncato (0.7.11)
+    truncato (0.7.12)
       htmlentities (~> 4.3.1)
       nokogiri (>= 1.7.0, <= 2.0)
     turbolinks (5.2.0)
@@ -368,7 +368,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   storyblok (~> 2.0.5)
   timecop (~> 0.9.1)
-  truncato
+  truncato (~> 0.7.12)
   turbolinks (~> 5.2)
   twitter_cldr (~> 4.4, >= 4.4.3)
   tzinfo-data


### PR DESCRIPTION
Currently, there is an issue with lesson cards where we see the following on each lesson card. This is due to a [compatibility issue Nokogiri](https://github.com/jorgemanrubia/truncato/issues/20).

<img width="736" alt="CleanShot 2023-07-25 at 14 17 34@2x" src="https://github.com/chaynHQ/soulmedicine/assets/564113/b627a21e-37cd-489c-a1f2-ec2e6150c164">

<br>

In order to fix this, I've upgraded the [truncato](https://rubygems.org/gems/truncato) gem [to the latest version](https://rubygems.org/gems/truncato/versions/0.7.12).

<img width="1840" alt="CleanShot 2023-07-25 at 19 54 32@2x" src="https://github.com/chaynHQ/soulmedicine/assets/564113/b78e56dd-f88a-4d01-b229-6255b3a37813">


