### PR TITLE
Update mime-types gem to remove logger warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,9 +146,9 @@ GEM
     meta-tags (2.11.1)
       actionpack (>= 3.2.0, < 6.1)
     method_source (1.0.0)
-    mime-types (3.2.2)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2023.0218.1)
     mimemagic (0.3.10)
       nokogiri (~> 1)
       rake


### PR DESCRIPTION
This updates the `mime-types` gem to remove the following warnings:

```
/app/vendor/bundle/ruby/2.7.0/gems/mime-types-3.2.2/lib/mime/types/logger.rb:30: warning: `_1' is reserved for numbered parameter; consider another name
/app/vendor/bundle/ruby/2.7.0/gems/mime-types-3.2.2/lib/mime/types/logger.rb:30: warning: `_2' is reserved for numbered parameter; consider another name
/app/vendor/bundle/ruby/2.7.0/gems/mime-types-3.2.2/lib/mime/types/logger.rb:30: warning: `_3' is reserved for numbered parameter; consider another name
```