### PR TITLE
Update ci.yml to use main instead of master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   erb_javascript_rails:


### PR DESCRIPTION
We're now using `main` as the default branch for the project 🎉 

We need to update the CI configuration so that it runs on PRs.