### PR TITLE
Don't force requests from old versions of IE to be UTF-8 encoded

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -7,7 +7,7 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
 # Don't force requests from old versions of IE to be UTF-8 encoded.
-# Rails.application.config.action_view.default_enforce_utf8 = false
+Rails.application.config.action_view.default_enforce_utf8 = false
 
 # Embed purpose and expiry metadata inside signed and encrypted
 # cookies for increased security.


### PR DESCRIPTION
This starts the process of rolling out the Rails 6 framework defaults in a controlled manner.

Since we're not worried about supporting really old versions of IE, I think this will be safe.