### PR TITLE
Fix autoloaded constant deprecation warning

### DIFF
--- a/config/initializers/locales.rb
+++ b/config/initializers/locales.rb
@@ -1,3 +1,5 @@
+require_relative '../../app/services/locales_service'
+
 enabled_locales_var = ENV.fetch('ENABLED_LOCALES') { raise 'ENABLED_LOCALES missing' }
 enabled_locales = enabled_locales_var.split(',').map(&:strip).map(&:downcase).map(&:to_sym)
 


### PR DESCRIPTION
We were getting the following warning after upgrading to [`zeitwerk` mode](https://guides.rubyonrails.org/v6.0/autoloading_and_reloading_constants.html).

```
DEPRECATION WARNING: Initialization autoloaded the constant LocalesService.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload LocalesService, for example,
the expected changes won't be reflected in that stale Module object.

This autoloaded constant has been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
 (called from <main> at /home/runner/work/soulmedicine/soulmedicine/config/environment.rb:15)
```

To fix this we are requiring the `LocaleService` explicitly as recommended by https://guides.rubyonrails.org/v6.0/autoloading_and_reloading_constants.html#ruby-constant-lookup-compliance