### PR TITLE
Embed purpose and expiry metadata inside signed and encrypted and cookies for increased security

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -14,7 +14,7 @@ Rails.application.config.action_view.default_enforce_utf8 = false
 #
 # This option is not backwards compatible with earlier Rails versions.
 # It's best enabled when your entire app is migrated and stable on 6.0.
-# Rails.application.config.action_dispatch.use_cookies_with_metadata = true
+Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 
 # Change the return value of `ActionDispatch::Response#content_type` to Content-Type header without modification.
 Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false


### PR DESCRIPTION
From the [Rails upgrade documentation](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#purpose-and-expiry-metadata-is-now-embedded-inside-signed-and-encrypted-cookies-for-increased-security):

> To improve security, Rails embeds the purpose and expiry metadata inside encrypted or signed cookies value.
>
>Rails can then thwart attacks that attempt to copy the signed/encrypted value of a cookie and use it as the value of another cookie.

This is the last PR we'll ship before cutting over to use 6.0 framework defaults 🎉 