### PR TITLE
Ensure the course for a Subscription is present as the last call before delivering the lesson

### DIFF
--- a/app/services/subscriptions_processor_service.rb
+++ b/app/services/subscriptions_processor_service.rb
@@ -20,9 +20,9 @@ class SubscriptionsProcessorService
     subscription.active? &&
       subscription.email? &&
       subscription.user.verified? &&
-      course_ok?(subscription) &&
       within_schedule?(subscription) &&
-      !delivered_within_last_hour?(subscription)
+      !delivered_within_last_hour?(subscription) &&
+      course_ok?(subscription)
   end
 
   def course_ok?(subscription)

--- a/spec/services/subscriptions_processor_service_spec.rb
+++ b/spec/services/subscriptions_processor_service_spec.rb
@@ -83,16 +83,14 @@ RSpec.describe SubscriptionsProcessorService, type: :service do
       context 'when course exists' do
         before do
           subscription.user.update! email_verified: true
-
-          expect(subject).to receive(:course_ok?)
-            .at_least(:once)
-            .and_call_original
         end
 
         context 'not within schedule' do
           before do
             days_utc = 1.day.from_now.utc.strftime('%a')
             subscription.update! days_utc: [days_utc]
+
+            expect(subject).to receive(:course_ok?).never
 
             expect(subject).to receive(:within_schedule?)
               .and_call_original
@@ -104,6 +102,8 @@ RSpec.describe SubscriptionsProcessorService, type: :service do
         context 'already delivered within the last hour' do
           before do
             subscription.update! last_delivered_at: 50.minutes.ago
+
+            expect(subject).to receive(:course_ok?).never
 
             expect(subject).to receive(:deliver_subscription_now?)
               .and_call_original
@@ -127,6 +127,10 @@ RSpec.describe SubscriptionsProcessorService, type: :service do
 
           before do
             other_subscription.user.update! email_verified: true
+
+            expect(subject).to receive(:course_ok?)
+              .at_least(:once)
+              .and_call_original
           end
 
           it 'delivers the lesson email for just that subscription' do


### PR DESCRIPTION
We're currently attempting to reduce the amount of memory used on the `worker` Dyno in Heroku.

As a first step, I'd like to propose checking the existence of the `Subscription`'s `course` as the last filter before delivering the lesson. This is the most expensive call, and currently we're checking every active subscription before ensuring we're supposed to be sending it in the current window.

I think the next step will be to break this process up into multiple smaller jobs to parallelize this work.