### PR TITLE
Add Scout APM gem for application performance tracing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'premailer-rails', '~>1.10.3'
 gem 'gemoji'
 gem 'truncato', '~> 0.7.12'
 gem 'barnes', '~> 0.0.9'
+gem 'scout_apm', '~> 5.3', '>= 5.3.5'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,8 @@ GEM
       rubocop (>= 1.33.0, < 2.0)
     ruby-progressbar (1.13.0)
     ruby_dep (1.5.0)
+    scout_apm (5.3.5)
+      parser
     semantic_range (3.0.0)
     shakapacker (7.0.2)
       activesupport (>= 5.2)
@@ -402,6 +404,7 @@ DEPENDENCIES
   rubocop (~> 1.28)
   rubocop-performance (~> 1.13)
   rubocop-rails (~> 2.14)
+  scout_apm (~> 5.3, >= 5.3.5)
   shakapacker (~> 7.0, >= 7.0.2)
   shallow_attributes (~> 0.9.4)
   sidekiq (~> 6.5, >= 6.5.9)


### PR DESCRIPTION
I'd like to add performance tracing to the application to get better insight as to why we're seeing spikes in request times. Currently I've enabled the free tier of [Scout APM](https://scoutapm.com/) which I think should be enough.