### PR TITLE
Generate CSRF tokens that are encoded in URL-safe Base64

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -29,7 +29,7 @@ Rails.application.config.active_job.skip_after_callbacks_if_terminated = true
 #
 # This change is not backwards compatible with earlier Rails versions.
 # It's best enabled when your entire app is migrated and stable on 6.1.
-# Rails.application.config.action_controller.urlsafe_csrf_tokens = true
+Rails.application.config.action_controller.urlsafe_csrf_tokens = true
 
 # Specify whether `ActiveSupport::TimeZone.utc_to_local` returns a time with an
 # UTC offset or a UTC time.


### PR DESCRIPTION
This updates the [CSRF tokens generated by Rails](https://guides.rubyonrails.org/security.html#cross-site-request-forgery-csrf) to be URL safe.

I took a look at the [changelog for reference](https://github.com/rails/rails/pull/18496) and I thought this was a great summary:

>   Base64 strict-encoded CSRF tokens are not inherently websafe, which makes
>   them difficult to deal with. For example, the common practice of sending
>   the CSRF token to a browser in a client-readable cookie does not work properly
>   out of the box: the value has to be url-encoded and decoded to survive transport.
>
>   Now, we generate Base64 urlsafe-encoded CSRF tokens, which are inherently safe
>   to transport.  Validation accepts both urlsafe tokens, and strict-encoded tokens
>   for backwards compatibility.

There may a be a slight blip if users are trying to submit a form at the time of rollout, but otherwise there shouldn't be any impact.