### PR TITLE
Update local Redis to match Heroku

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,11 @@ services:
     ports:
       - 5432:5432
   redis-sidekiq:
-    image: redis:5.0.3-alpine
+    image: redis:6.2.13-alpine
     ports:
       - 6379:6379
   redis-cache:
-    image: redis:5.0.3-alpine
+    image: redis:6.2.13-alpine
     ports:
       - 6380:6379
   mailcatcher:


### PR DESCRIPTION
This updates our local Redis version to 6.2.13 which is what we have running on Heroku. I updated this to test the new version of Sidekiq and then forgot to commit it 🤦 