### PR TITLE
Create `rollbar` queue for Sidekiq

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+---
+:queues:
+  - default
+  - rollbar

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
 ---
 :queues:
-  - [default, 1]
+  - default
   - [rollbar, 2]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
 ---
 :queues:
-  - default
-  - rollbar
+  - [default, 1]
+  - [rollbar, 2]


### PR DESCRIPTION
In the documentation https://docs.rollbar.com/docs/sidekiq-integration I missed the fact that the Rollbar Sidekiq integration requires us to either define a 'rollbar' queue, or overwrite the name of the queue in the Rails app.

This configuration means that the `rollbar` queue will be checked twice as often as the `default` queue.

The `default` queue is used for backups and lesson emails.