### PR TITLE
Upgrade @rails/ujs to match the current Ruby on Rails version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@babel/plugin-transform-runtime": "7",
     "@babel/preset-env": "7",
     "@babel/runtime": "7",
-    "@rails/ujs": "6.0.6-1",
+    "@rails/ujs": "6.1.7-6",
     "axios": "^1.4.0",
     "babel-loader": "8",
     "bootstrap": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,10 +1816,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@rails/ujs@6.0.6-1":
-  version "6.0.6-1"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.0.6-1.tgz#a30b0879203144eeb6cc91bce78a751ff99bdc3a"
-  integrity sha512-E0MZU0l3XWZirpqRhGfA1M9fJF4ydUw6NK4mxdvekeRJcBtvwBtaOJySoZjS/9YM6pHSvA9fjhQkNEiRPRT9Ng==
+"@rails/ujs@6.1.7-6":
+  version "6.1.7-6"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.7-6.tgz#b8029ac3347002b58b0a8ff7d1bb2dc081289d3f"
+  integrity sha512-nFGvNDY8l3BNV8wnACj632E3pu+Fh3+nnJT2kuiHyjvaPnv+0HYzkk1dSQCb5XUS8FzBIj4iJnGheGF9Du80gg==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"


### PR DESCRIPTION
This updates the [@rails/ujs](https://www.npmjs.com/package/@rails/ujs) package to match the current version of Ruby on Rails that is currently running in production.