### PR TITLE
docs: changed getting involved link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See our [documentation](docs/README.md) if you're interested in developing or te
 
 # Get Involved
 
-If you would like to help Chayn and receive special access to our organization and volunteer opportunities, please get in touch with us to express your interest in volunteering via [this form](https://forms.gle/qXfDdPgJxYwvMmVP7). We'll get back to you to schedule an onboarding call. Other ways to get involved and support us are [donating](https://www.paypal.me/chaynhq), making an open-source contribution here on GitHub, and supporting us on social media! 
+If you would like to help Chayn and receive special access to our organization and volunteer opportunities, please visit our [Getting Involved page](https://chayn.notion.site/Get-involved-423c067536f3426a88005de68f0cab19). We'll get back to you to schedule an onboarding call. Other ways to get involved and support us are [donating](https://www.paypal.me/chaynhq), making an open-source contribution here on GitHub, and supporting us on social media! 
 
 Stay up to date with Chayn:
 


### PR DESCRIPTION
# Issue

Fixes #386 

# Description

Replaced the form link in the Get Involved section of the README with a link to the Getting Involved Page.

# Checklist

- [X] Replace the text in the README.md under the Getting Involved section:
If you would like to help Bloom and receive special access to our organization and volunteer opportunities, please get in touch with us to express your interest in volunteering via [this form](https://forms.gle/qXfDdPgJxYwvMmVP7)."
with the following text:
"If you would like to help Chayn and receive special access to our organization and volunteer opportunities, please visit our Getting Involved page."
- [X] Make sure the above sentence contains a markdown link to our Getting Involved page: https://www.notion.so/chayn/Get-involved-423c067536f3426a88005de68f0cab19?pvs=4
