### PR TITLE
Enforce SSL in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
### Issue ticket link / number:

No ticket sorry 😅 

### What changes did you make?

I've updated our production configuration so that we always require SSL for accessing the app.

### Why did you make the changes?

This is to prevent [Session Hijacking](https://guides.rubyonrails.org/security.html#session-hijacking).

<!--- PR CHECKLIST: PLEASE REMOVE BEFORE SUBMITTING —>
- [ ] You have answered the above questions.
- [ ] You have followed the guidelines in the CONTRIBUTING.md file
- [ ] You have a descriptive and concise PR title.
