### PR TITLE
Update digest class to SHA256

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -28,7 +28,7 @@ Rails.application.config.action_view.button_to_generates_button_tag = true
 # Change the digest class for ActiveSupport::Digest.
 # Changing this default means that for example Etags change and
 # various cache keys leading to cache invalidation.
-# Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
 
 # Don't override ActiveSupport::TimeWithZone.name and use the default Ruby
 # implementation.


### PR DESCRIPTION
### Issue ticket link / number:

https://github.com/chaynHQ/soulmedicine/issues/391

### What changes did you make?

This updates the digest class for `ActiveSupport::Digest` to use `OpenSSL::Digest::SHA256`. This digest is used for things like ETags and ActiveRecord query caching.

### Why did you make the changes?

This is the new standard recommendation from Rails. See https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#digest-class-for-activesupport-digest-changing-to-sha256

<!--- PR CHECKLIST: PLEASE REMOVE BEFORE SUBMITTING —>
- [ ] You have answered the above questions.
- [ ] You have followed the guidelines in the CONTRIBUTING.md file
- [ ] You have a descriptive and concise PR title.
