### PR TITLE
Fix: Fix TimeZoneScheduleConverter tests

### DIFF
--- a/spec/lib/time_zone_schedule_converter_spec.rb
+++ b/spec/lib/time_zone_schedule_converter_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe TimeZoneScheduleConverter do
         let(:hour) { 0 }
         let(:adjusted_hour) { 24 + to_zone_offset }
 
-        it 'returns the adjusted hour and previous day(s)' do  
+        it 'returns the adjusted hour and previous day(s)' do
           expect(subject).to eq(
             days: %w[Sat Tue Fri],
             hour: adjusted_hour

--- a/spec/lib/time_zone_schedule_converter_spec.rb
+++ b/spec/lib/time_zone_schedule_converter_spec.rb
@@ -77,10 +77,10 @@ RSpec.describe TimeZoneScheduleConverter do
       context 'when the adjusted hour moves behind into previous day(s)' do
         let(:from_zone) { 'UTC' }
         let(:to_zone) { 'Greenland' }
-        let(:hour) { 1 }
-        let(:adjusted_hour) { 24 + to_zone_offset + 1 }
+        let(:hour) { 0 }
+        let(:adjusted_hour) { 24 + to_zone_offset }
 
-        it 'returns the adjusted hour and previous day(s)' do
+        it 'returns the adjusted hour and previous day(s)' do  
           expect(subject).to eq(
             days: %w[Sat Tue Fri],
             hour: adjusted_hour


### PR DESCRIPTION
Fix TimeZoneScheduleConverter test, changing some test values in order to obtain the expected result from the service.

### Issue link / number: #456

### What changes did you make? 

I fixed a broken tests related to the service `TimeZoneScheduleConverter`.
Looks like the service is working properly, so the error was in the test values.

### Why did you make the changes?

To fix the broken tests and to have a clean pipeline.